### PR TITLE
Change ESM import to default import

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,7 +37,7 @@ window.onresize.flush();
 Alternately, if using newer syntax:
 
 ```js
-import { debounce } from "debounce";
+import debounce from "debounce";
 ```
 
 ## API


### PR DESCRIPTION
When using a setup that follows the ESM spec such as ESM in Node or in the browser directly, the named import in the documentation. By using a default import instead it will work as expected. 

This has likely been abstracted away by "bundler magic" in webpack, but fails in these more strict environments.

**Example**: [JSPM Sandbox for Named Import](https://jspm.org/sandbox#H4sIAAAAAAAAA3VTXU/bMBR9Xn/FJXsBjcRtpUldSSq6USEQqbZFnbRH13YbM39EtkMJiP8+x2k6qNhDZPnec8+951wnPaGauKZiUDopZoO0PximswFAKpnDQEpsLHNZVLtNPIlCwnEn2GylwklT1N0PJQpLlkUPnO0qbVwERCvHlKfYcerKjLIHTlgcLufAFXcci9gSLFg28g1S1E2QrjVtAutJHPsD4Lb4nsM1U8xgpw3cyJYfclyF7IJyB6ufd1Ovx1V2itC2hyb3tpIJ1+jjavyr/H399c9VPjRN8XRbrEZlsRDLhqNlMfw8ypc/nob3+WJ+t7Wk3NH53HPHcRjDEsMrB61lWcRDc4mrYMlzmGAftNF0H/Ahyta6VoT5WHSYCx8GUpWc9pDLUTJORogryh49IAoUL4PuS1HXvu229wQWBeSa1oJBUXJpp70jfioLlRbNhgsBG2+VDDALa6N3lhkLO+5KXTvgrypsXYXLKfZV7JEwL/ZbabRkMPny6ezIBmwbRcAakv1PF7Nx1ze27XiXw2Q0TiaIcuvQUS6RXLWSgRhtrTZ8y1UWYaVVI3Vto9mx/De76JjCIqBX9Ay9rfACGy/i1SouPPADQj20j1+xDa6Few8dmP07tlqwROjtabT0j5x6l1oGv9rzA8vZRQAj9Abec79TsE+Fun8yU9Q9f/83hN/yL34j9y2uAwAA) (Errors)
**Example**: [JSPM Sandbox for Default Import](https://jspm.org/sandbox#H4sIAAAAAAAAA3VT32+bMBB+Xv6KK3tptQEh0qQshajZFlWrSrQNZdIeHfsS3GEb2aaUTvvfZ0yI2kh7QCffj+++++5IL5iitqsRSiuq5SQdDRK2nACkAi0BWhJt0GZBY/fhPPABy22Fy630lqXx8D6VSCIwCx45trXSNgCqpEXpIFrObJkxfOQUQ/94D1xyy0kVGkoqzBLXII0HBulOsc6jXoShMwB3xbccblGiJlZp+Cp6fMhJ7aNrxi1sf9wv3Dy2Nos4Poyp0YOpRcRV/HY7+1n+uv30+0s+1V3xfFdsk7JYV5uOx5ti+iHJN9+fpw/5enV/MLRs2WrlsMPQ0zBU89pCL1kWcN9ckNpL8sczODpNsDg6nIvhTjWSovMFJ17kREjWYjGm3CTRLEpiLhk+uYTAQ/ydDF8aD+37bkdNYF1ArlhTIRQlF2YxKuJYGahV1e15VcHeSSV8moGdVq1BbaDltlSNBf6iwjS1f1wSV4VPFN2wn0utBML847urMxmI6SQFo2n2v7nQhEPf0PT0bqZRMovmMePGxmexSHDZjwxUK2OU5gcus4BIJTuhGhMsz8d/tYsByS/izXGgUVPYO/4vtnA91EN/lEZVGFXqcDlGr65fCZ3GwwW6g/R/xj9JCHx0MQMAAA==) (Works)