### PR TITLE
Fix the class context validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,8 +40,12 @@ function debounce(function_, wait = 100, options = {}) {
 	}
 
 	const debounced = function (...arguments_) {
-		if (storedContext && this !== storedContext) {
-			throw new Error('Debounced method called with different contexts.');
+		if (
+			storedContext
+			&& this !== storedContext
+			&& Object.getPrototypeOf(this) === Object.getPrototypeOf(storedContext)
+		) {
+			throw new Error('Debounced method called with different contexts of the same prototype.');
 		}
 
 		storedContext = this; // eslint-disable-line unicorn/no-this-assignment

--- a/test.js
+++ b/test.js
@@ -162,7 +162,7 @@ test('context check in debounced function', async t => {
 			instance2.debounced();
 		} catch (error) {
 			errorThrown = true;
-			assert.strictEqual(error.message, 'Debounced method called with different contexts.', 'Error message should match');
+			assert.strictEqual(error.message, 'Debounced method called with different contexts of the same prototype.', 'Error message should match');
 		}
 
 		assert.ok(errorThrown, 'An error should have been thrown');

--- a/test.js
+++ b/test.js
@@ -147,7 +147,7 @@ test('forcing execution', async t => {
 });
 
 test('context check in debounced function', async t => {
-	await t.test('should throw an error if debounced method is called with different contexts', async () => {
+	await t.test('should throw an error if debounced method is called with different contexts of the same class', async () => {
 		function MyClass() {}
 
 		MyClass.prototype.debounced = debounce(() => {});
@@ -161,7 +161,28 @@ test('context check in debounced function', async t => {
 			instance2.debounced();
 		}, {
 			message: 'Debounced method called with different contexts of the same prototype.',
-		});
+		}, 'An error should have been thrown');
+	});
+
+	await t.test('should not throw an error if debounced method is called with different contexts of different classes', async () => {
+		function MyClass1() {}
+		function MyClass2() {}
+
+		const debouncedFunction = debounce(() => {});
+
+		MyClass1.prototype.debounced = debouncedFunction;
+		MyClass2.prototype.debounced = debouncedFunction;
+
+		const instance1 = new MyClass1();
+		const instance2 = new MyClass2();
+
+		instance1.debounced();
+
+		assert.doesNotThrow(() => {
+			instance2.debounced();
+		}, {
+			message: 'Debounced method called with different contexts of the same prototype.',
+		}, 'An error should not have been thrown');
 	});
 });
 

--- a/test.js
+++ b/test.js
@@ -157,15 +157,11 @@ test('context check in debounced function', async t => {
 
 		instance1.debounced();
 
-		let errorThrown = false;
-		try {
+		assert.throws(() => {
 			instance2.debounced();
-		} catch (error) {
-			errorThrown = true;
-			assert.strictEqual(error.message, 'Debounced method called with different contexts of the same prototype.', 'Error message should match');
-		}
-
-		assert.ok(errorThrown, 'An error should have been thrown');
+		}, {
+			message: 'Debounced method called with different contexts of the same prototype.',
+		});
 	});
 });
 


### PR DESCRIPTION
## Issue
Context equality protection is indeed useful when you want to protect the same function from running on two distinct instances, as described in #8. However, equality isn't always expected. Here's an example:
```ts
const onResize = debounce(() => {...});

window.addEventListener('resize', onResize);
const resizeObserver = new ResizeObserver(onResize);
```
In this case, I **want** to operate a **single debounced function** that will shared between the event listener and resize observer. However, when the function gets invoked, it receives different contexts that lead to the exception:
![image](https://github.com/user-attachments/assets/1ca2cefc-76e8-4a08-81b2-a3a85521e689)
However, those contexts come from totally different classes and don't violate the issue described in #8.

## Changes Made
Additionally to the context check, I also added the prototype equality check. That will help to dismiss false exceptions when the context differs between instances of unrelated classes.